### PR TITLE
Add the parameters used by pairing gadgets into the ppT structure, so

### DIFF
--- a/libff/algebra/curves/mnt/mnt4/mnt4_init.cpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_init.cpp
@@ -11,6 +11,7 @@
 #include <libff/algebra/curves/mnt/mnt4/mnt4_g1.hpp>
 #include <libff/algebra/curves/mnt/mnt4/mnt4_g2.hpp>
 #include <libff/algebra/curves/mnt/mnt4/mnt4_init.hpp>
+#include <libff/algebra/curves/mnt/mnt4/mnt4_pp.hpp>
 
 namespace libff {
 
@@ -114,7 +115,7 @@ void init_mnt4_params()
     /* choice of short Weierstrass curve and its twist */
     mnt4_G1::coeff_a = mnt4_Fq("2");
     mnt4_G1::coeff_b = mnt4_Fq("423894536526684178289416011533888240029318103673896002803341544124054745019340795360841685");
-    mnt4_twist = mnt4_Fq2(mnt4_Fq::zero(), mnt4_Fq::one());
+    mnt4_pp::Fq2_twist = mnt4_twist = mnt4_Fq2(mnt4_Fq::zero(), mnt4_Fq::one());
     mnt4_twist_coeff_a = mnt4_Fq2(mnt4_G1::coeff_a * mnt4_Fq2::non_residue, mnt4_Fq::zero());
     mnt4_twist_coeff_b = mnt4_Fq2(mnt4_Fq::zero(), mnt4_G1::coeff_b * mnt4_Fq2::non_residue);
     mnt4_G2::twist = mnt4_twist;

--- a/libff/algebra/curves/mnt/mnt4/mnt4_pp.cpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_pp.cpp
@@ -15,6 +15,8 @@
 
 namespace libff {
 
+mnt4_Fq2 mnt4_pp::Fq2_twist;
+
 void mnt4_pp::init_public_params()
 {
     init_mnt4_params();

--- a/libff/algebra/curves/mnt/mnt4/mnt4_pp.hpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_pp.hpp
@@ -34,6 +34,14 @@ public:
     typedef mnt4_Fq4 Fqk_type;
     typedef mnt4_GT GT_type;
 
+    static mnt4_Fq2 Fq2_twist;
+
+    static constexpr mp_size_t r_limbs = mnt46_A_limbs;
+    static constexpr mp_size_t q_limbs = mnt46_B_limbs;
+    static constexpr bigint<mnt4_q_limbs> &final_exponent_last_chunk_abs_of_w0 = mnt4_final_exponent_last_chunk_abs_of_w0;
+    static constexpr bool &final_exponent_last_chunk_is_w0_neg = mnt4_final_exponent_last_chunk_is_w0_neg;
+    static constexpr bigint<mnt4_q_limbs> &final_exponent_last_chunk_w1 = mnt4_final_exponent_last_chunk_w1;
+
     static const bool has_affine_pairing = true;
 
     static void init_public_params();

--- a/libff/algebra/curves/mnt/mnt6/mnt6_init.cpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_init.cpp
@@ -11,6 +11,7 @@
 #include <libff/algebra/curves/mnt/mnt6/mnt6_g1.hpp>
 #include <libff/algebra/curves/mnt/mnt6/mnt6_g2.hpp>
 #include <libff/algebra/curves/mnt/mnt6/mnt6_init.hpp>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
 
 namespace libff {
 
@@ -123,7 +124,7 @@ void init_mnt6_params()
     /* choice of short Weierstrass curve and its twist */
     mnt6_G1::coeff_a = mnt6_Fq("11");
     mnt6_G1::coeff_b = mnt6_Fq("106700080510851735677967319632585352256454251201367587890185989362936000262606668469523074");
-    mnt6_twist = mnt6_Fq3(mnt6_Fq::zero(), mnt6_Fq::one(), mnt6_Fq::zero());
+    mnt6_pp::Fq3_twist = mnt6_twist = mnt6_Fq3(mnt6_Fq::zero(), mnt6_Fq::one(), mnt6_Fq::zero());
     mnt6_twist_coeff_a = mnt6_Fq3(mnt6_Fq::zero(), mnt6_Fq::zero(),
                                   mnt6_G1::coeff_a);
     mnt6_twist_coeff_b = mnt6_Fq3(mnt6_G1::coeff_b * mnt6_Fq3::non_residue,

--- a/libff/algebra/curves/mnt/mnt6/mnt6_pp.cpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_pp.cpp
@@ -15,6 +15,8 @@
 
 namespace libff {
 
+mnt6_Fq3 mnt6_pp::Fq3_twist;
+
 void mnt6_pp::init_public_params()
 {
     init_mnt6_params();

--- a/libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp
@@ -36,6 +36,14 @@ public:
 
     static const bool has_affine_pairing = true;
 
+    static constexpr mp_size_t r_limbs = mnt46_B_limbs;
+    static constexpr mp_size_t q_limbs = mnt46_A_limbs;
+    static constexpr bigint<mnt6_q_limbs> &final_exponent_last_chunk_abs_of_w0 = mnt6_final_exponent_last_chunk_abs_of_w0;
+    static constexpr bool &final_exponent_last_chunk_is_w0_neg = mnt6_final_exponent_last_chunk_is_w0_neg;
+    static constexpr bigint<mnt6_q_limbs> &final_exponent_last_chunk_w1 = mnt6_final_exponent_last_chunk_w1;
+
+    static mnt6_Fq3 Fq3_twist;
+
     static void init_public_params();
     static mnt6_GT final_exponentiation(const mnt6_Fq6 &elt);
     static mnt6_G1_precomp precompute_G1(const mnt6_G1 &P);

--- a/libff/algebra/curves/mnt753/mnt4753/mnt4753_init.cpp
+++ b/libff/algebra/curves/mnt753/mnt4753/mnt4753_init.cpp
@@ -11,6 +11,7 @@
 #include <libff/algebra/curves/mnt753/mnt4753/mnt4753_g1.hpp>
 #include <libff/algebra/curves/mnt753/mnt4753/mnt4753_g2.hpp>
 #include <libff/algebra/curves/mnt753/mnt4753/mnt4753_init.hpp>
+#include <libff/algebra/curves/mnt753/mnt4753/mnt4753_pp.hpp>
 
 namespace libff {
 
@@ -115,7 +116,7 @@ void init_mnt4753_params()
     /* choice of short Weierstrass curve and its twist */
     mnt4753_G1::coeff_a = mnt4753_Fq("2");
     mnt4753_G1::coeff_b = mnt4753_Fq("28798803903456388891410036793299405764940372360099938340752576406393880372126970068421383312482853541572780087363938442377933706865252053507077543420534380486492786626556269083255657125025963825610840222568694137138741554679540");
-    mnt4753_twist = mnt4753_Fq2(mnt4753_Fq::zero(), mnt4753_Fq::one());
+    mnt4753_pp::Fq2_twist = mnt4753_twist = mnt4753_Fq2(mnt4753_Fq::zero(), mnt4753_Fq::one());
     mnt4753_twist_coeff_a = mnt4753_Fq2(mnt4753_G1::coeff_a * mnt4753_Fq2::non_residue, mnt4753_Fq::zero());
     mnt4753_twist_coeff_b = mnt4753_Fq2(mnt4753_Fq::zero(), mnt4753_G1::coeff_b * mnt4753_Fq2::non_residue);
     mnt4753_G2::twist = mnt4753_twist;

--- a/libff/algebra/curves/mnt753/mnt4753/mnt4753_pp.cpp
+++ b/libff/algebra/curves/mnt753/mnt4753/mnt4753_pp.cpp
@@ -2,6 +2,8 @@
 
 namespace libff {
 
+mnt4753_Fq2 mnt4753_pp::Fq2_twist;
+
 void mnt4753_pp::init_public_params()
 {
     init_mnt4753_params();

--- a/libff/algebra/curves/mnt753/mnt4753/mnt4753_pp.hpp
+++ b/libff/algebra/curves/mnt753/mnt4753/mnt4753_pp.hpp
@@ -23,6 +23,14 @@ public:
     typedef mnt4753_Fq4 Fqk_type;
     typedef mnt4753_GT GT_type;
 
+    static constexpr mp_size_t r_limbs = mnt46753_A_limbs;
+    static constexpr mp_size_t q_limbs = mnt46753_B_limbs;
+    static constexpr bigint<mnt4753_q_limbs> &final_exponent_last_chunk_abs_of_w0 = mnt4753_final_exponent_last_chunk_abs_of_w0;
+    static constexpr bool &final_exponent_last_chunk_is_w0_neg = mnt4753_final_exponent_last_chunk_is_w0_neg;
+    static constexpr bigint<mnt4753_q_limbs> &final_exponent_last_chunk_w1 = mnt4753_final_exponent_last_chunk_w1;
+
+    static mnt4753_Fq2 Fq2_twist;
+
     static const bool has_affine_pairing = true;
 
     static void init_public_params();

--- a/libff/algebra/curves/mnt753/mnt6753/mnt6753_init.cpp
+++ b/libff/algebra/curves/mnt753/mnt6753/mnt6753_init.cpp
@@ -1,6 +1,7 @@
 #include <libff/algebra/curves/mnt753/mnt6753/mnt6753_g1.hpp>
 #include <libff/algebra/curves/mnt753/mnt6753/mnt6753_g2.hpp>
 #include <libff/algebra/curves/mnt753/mnt6753/mnt6753_init.hpp>
+#include <libff/algebra/curves/mnt753/mnt6753/mnt6753_pp.hpp>
 
 namespace libff {
 
@@ -116,7 +117,7 @@ void init_mnt6753_params()
     /* choice of short Weierstrass curve and its twist */
     mnt6753_G1::coeff_a = mnt6753_Fq("11");
     mnt6753_G1::coeff_b = mnt6753_Fq("11625908999541321152027340224010374716841167701783584648338908235410859267060079819722747939267925389062611062156601938166010098747920378738927832658133625454260115409075816187555055859490253375704728027944315501122723426879114");
-    mnt6753_twist = mnt6753_Fq3(mnt6753_Fq::zero(), mnt6753_Fq::one(), mnt6753_Fq::zero());
+    mnt6753_pp::Fq3_twist = mnt6753_twist = mnt6753_Fq3(mnt6753_Fq::zero(), mnt6753_Fq::one(), mnt6753_Fq::zero());
     mnt6753_twist_coeff_a = mnt6753_Fq3(mnt6753_Fq::zero(), mnt6753_Fq::zero(),
                                   mnt6753_G1::coeff_a);
     mnt6753_twist_coeff_b = mnt6753_Fq3(mnt6753_G1::coeff_b * mnt6753_Fq3::non_residue,

--- a/libff/algebra/curves/mnt753/mnt6753/mnt6753_pp.cpp
+++ b/libff/algebra/curves/mnt753/mnt6753/mnt6753_pp.cpp
@@ -2,6 +2,8 @@
 
 namespace libff {
 
+mnt6753_Fq3 mnt6753_pp::Fq3_twist;
+
 void mnt6753_pp::init_public_params()
 {
     init_mnt6753_params();

--- a/libff/algebra/curves/mnt753/mnt6753/mnt6753_pp.hpp
+++ b/libff/algebra/curves/mnt753/mnt6753/mnt6753_pp.hpp
@@ -23,6 +23,14 @@ public:
     typedef mnt6753_Fq6 Fqk_type;
     typedef mnt6753_GT GT_type;
 
+    static constexpr mp_size_t r_limbs = mnt46753_B_limbs;
+    static constexpr mp_size_t q_limbs = mnt46753_A_limbs;
+    static constexpr bigint<mnt6753_q_limbs> &final_exponent_last_chunk_abs_of_w0 = mnt6753_final_exponent_last_chunk_abs_of_w0;
+    static constexpr bool &final_exponent_last_chunk_is_w0_neg = mnt6753_final_exponent_last_chunk_is_w0_neg;
+    static constexpr bigint<mnt6753_q_limbs> &final_exponent_last_chunk_w1 = mnt6753_final_exponent_last_chunk_w1;
+
+    static mnt6753_Fq3 Fq3_twist;
+
     static const bool has_affine_pairing = true;
 
     static void init_public_params();


### PR DESCRIPTION
they can be used without hard-coding either mnt4 or mnt6

This allows mnt[46]753 to be used with in-SNARK pairing gadgets

